### PR TITLE
Include HTTP headers in trace event

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ http {
      listen 8888;
      server_name example.com;
 
+     akita_agent localhost:5555;
+
      location / {
         proxy_pass http://127.0.0.1:8000/;
-        akita_agent localhost:5555;
+        akita_enable on;
      }
  
      # This is a placeholder that will be replaced by a proper upstream.

--- a/src/akita_client.c
+++ b/src/akita_client.c
@@ -5,10 +5,6 @@
 #include "ngx_http_akita_module.h"
 #include "akita_client.h"
 
-static ngx_int_t
-akita_get_request_id(ngx_http_request_t *r, ngx_str_t *dest);
-
-
 /* Functions for generating JSON objects. */
 
 /* A chain of buffers holding the JSON output */
@@ -25,7 +21,8 @@ static unsigned char * json_ensure_space( json_data_t *buf, ngx_uint_t size );
 static void json_write_char( json_data_t *buf, unsigned char c );
 static void json_write_string_literal( json_data_t *buf, ngx_str_t *str );
 static void json_write_time_literal( json_data_t *buf, struct timeval *tm  );
-/* TODO: static void json_write_int_literal( json_data_t *buf, ngx_uint_t n ); */
+static void json_write_uint_literal( json_data_t *buf, ngx_uint_t n );
+static void json_snprintf(json_data_t *j, size_t max_len, const char *fmt, ...);
 
 /* A key and string value to write into a JSON object */
 typedef struct json_kv_string_s {
@@ -36,6 +33,12 @@ typedef struct json_kv_string_s {
 
 static void json_write_kv_strings( json_data_t *buf, json_kv_string_t *kvs );
 
+static ngx_int_t ngx_akita_get_request_id(ngx_http_request_t *r, ngx_str_t *dest);
+static void ngx_akita_write_request_headers(json_data_t *j, ngx_http_request_t *r );
+static void ngx_akita_write_body(json_data_t *j, ngx_http_request_t *r, size_t max_size );
+static void ngx_akita_clear_headers(ngx_http_request_t *r);
+static ngx_int_t ngx_akita_set_request_size(ngx_http_request_t *r, ngx_uint_t content_length);
+static ngx_int_t ngx_akita_set_json_content_type(ngx_http_request_t *r);
 
 static const ngx_uint_t json_initial_size = 4096;
 
@@ -131,10 +134,33 @@ static void json_write_string_literal(json_data_t *j, ngx_str_t *str) {
     return;
   }
   *dst++ = '"';
-  dst = (unsigned char *)ngx_escape_json( dst, str->data, str->len );
+  dst = (unsigned char *)ngx_escape_json(dst, str->data, str->len);
   *dst++ = '"';
   j->content_length += sz;
   j->tail->buf->last = dst;
+}
+
+/* Printf to a JSON buffer; may set `j->oom' on failure. */
+static void json_snprintf(json_data_t *j, size_t max_len, const char *fmt, ...) {
+  u_char *dst, *end;
+  va_list args;
+  va_start(args, fmt);
+
+  dst = json_ensure_space(j, max_len);
+  if (dst == NULL) {
+    return;
+  }
+  
+  end = ngx_vslprintf(dst, dst+max_len, fmt, args);
+  j->content_length += (end - dst);
+  j->tail->buf->last = end;  
+}
+
+/* Write an unsigned integer to the JSON buffer.
+   Sets 'j->oom' if an error occurs. */
+static void json_write_uint_literal(json_data_t *j, ngx_uint_t n) {
+  const int max_decimal_len = 20; /* handles 64-bit unsigned */
+  json_snprintf(j, max_decimal_len, "%ud", n);
 }
 
 /*
@@ -171,19 +197,12 @@ static void json_write_kv_strings(json_data_t *j, json_kv_string_t *kv) {
 static void json_write_time_literal(json_data_t *j, struct timeval *tv) {
   static ngx_str_t format = ngx_string("\"2006-01-02T15:04:05.999999Z\"");
   ngx_tm_t tm;
-
-  ngx_gmtime(tv->tv_sec, &tm);  
-  unsigned char *p = json_ensure_space(j, format.len);
-  if (p == NULL) {
-    return;
-  }
-  ngx_sprintf(p, "\"%4d-%02d-%02dT%02d:%02d:%02d.%06dZ\"",
-              tm.ngx_tm_year, tm.ngx_tm_mon,
-              tm.ngx_tm_mday, tm.ngx_tm_hour,
-              tm.ngx_tm_min, tm.ngx_tm_sec,
-              tv->tv_usec);
-  j->content_length += format.len;
-  j->tail->buf->last += format.len;    
+  ngx_gmtime(tv->tv_sec, &tm);
+  json_snprintf(j, format.len, "\"%4d-%02d-%02dT%02d:%02d:%02d.%06dZ\"",
+                tm.ngx_tm_year, tm.ngx_tm_mon,
+                tm.ngx_tm_mday, tm.ngx_tm_hour,
+                tm.ngx_tm_min, tm.ngx_tm_sec,
+                tv->tv_usec);
 }
 
 /* API request schema and subrequest manipulation */
@@ -213,9 +232,8 @@ static ngx_int_t ngx_request_id_index = 0;
  * TODO: for ngx prior to 1.11.0, we need to use the connection and
  * connection requests to generate an ID.
  */
-static
-ngx_int_t
-akita_get_request_id(ngx_http_request_t *r, ngx_str_t *dest) {
+static ngx_int_t
+ngx_akita_get_request_id(ngx_http_request_t *r, ngx_str_t *dest) {
   ngx_http_variable_value_t *v;
   
   v = ngx_http_get_indexed_variable(r, ngx_request_id_index);
@@ -269,6 +287,99 @@ ngx_akita_write_request_headers(json_data_t *j, ngx_http_request_t *r ) {
     }
   }
   json_write_char(j, ']' );  
+}
+
+/* Write the contents of the body, up to the given size, as a 
+   JSON literal string. If the content is truncated,
+   indicate this by a "truncated" field giving the truncated size. */
+static void
+ngx_akita_write_body(json_data_t *j, ngx_http_request_t *r, size_t max_size ) {
+  uintptr_t sz;
+  ngx_chain_t  *in;
+  static unsigned char *unescaped, *dst;
+  static unsigned char *file_buf = NULL;
+  size_t unescaped_len = 0;
+  size_t mirrored = 0;  /* must be <= max_size */
+  size_t truncated = 0; 
+  static ngx_str_t body_key = ngx_string( "body" );
+  static ngx_str_t truncated_key = ngx_string( "truncated" );
+  
+  json_write_string_literal( j, &body_key );
+  json_write_char( j, ':' );
+  json_write_char( j, '"' );
+
+  if (r->request_body == NULL) {
+    json_write_char( j, '"' );
+    return;
+  }
+  
+  for (in = r->request_body->bufs; in; in = in->next) {
+    /* Add up size after hitting limit*/
+    if (truncated > 0) {
+      truncated += ngx_buf_size(in->buf);
+      continue;
+    }
+    if (ngx_buf_in_memory(in->buf)) {
+      unescaped = in->buf->pos;
+      unescaped_len = in->buf->last - in->buf->pos;
+
+      /* Trim to maximum size, flag truncation. */
+      if (mirrored + unescaped_len > max_size) {
+        truncated = mirrored + unescaped_len;
+        unescaped_len = max_size - mirrored;
+      }
+    } else if (in->buf->in_file) {
+      /* Allocate a buffer and read only as much as we need from the file */
+      unescaped_len = in->buf->file_last - in->buf->file_pos;
+
+      if (mirrored + unescaped_len > max_size) {
+        truncated = mirrored + unescaped_len;
+        unescaped_len = max_size - mirrored;
+      }
+
+      /* Allocate a buffer; don't bother clearing it? */
+      file_buf = ngx_palloc(r->connection->pool, unescaped_len);
+      if (file_buf == NULL) {
+        j->oom = 1;
+        return;
+      }
+
+      /* TODO: this is blocking, but I don't know how to go through the
+       * event system to make it nonblocking. */
+      ngx_read_file( in->buf->file, file_buf, unescaped_len, in->buf->file_pos );
+      unescaped = file_buf;
+    } else if (in->buf->last_buf) {
+      break;
+    } else {
+      ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "Unexpected buffer state");
+      break;
+    }
+
+    sz = ngx_escape_json( NULL, unescaped, unescaped_len );
+    dst = json_ensure_space( j, unescaped_len + sz );
+    if (dst == NULL) {
+      return;
+    }
+    dst = (unsigned char *)ngx_escape_json( dst, unescaped, unescaped_len );
+    mirrored += unescaped_len;
+    j->content_length += (unescaped_len + sz);
+    j->tail->buf->last = dst;
+
+    if (file_buf != NULL) {
+      /* If the buffer was large enough, return it to the system allocator */
+      ngx_pfree(r->connection->pool, file_buf);
+      file_buf = NULL;
+    }
+  }
+
+  json_write_char( j, '"' );
+
+  if (truncated > 0) {
+    json_write_char(j, ',');
+    json_write_string_literal(j, &truncated_key);
+    json_write_char(j, ':');
+    json_write_uint_literal(j, truncated);
+  }
 }
 
 /* Set the input (request body) content size on a request. */
@@ -348,6 +459,7 @@ static ngx_str_t post_method = ngx_string("POST");
 ngx_int_t
 ngx_akita_send_request_body(ngx_http_request_t *r, ngx_str_t agent_path,
                             ngx_http_akita_ctx_t *ctx,
+                            ngx_http_akita_loc_conf_t *config,
                             ngx_http_post_subrequest_t *callback) {
   json_data_t *j;
   ngx_str_t request_id;
@@ -361,7 +473,7 @@ ngx_akita_send_request_body(ngx_http_request_t *r, ngx_str_t agent_path,
     return NGX_ERROR;
   }
   
-  rc = akita_get_request_id(r, &request_id );
+  rc = ngx_akita_get_request_id(r, &request_id );
   if (rc != NGX_OK) {
     ngx_log_error( NGX_LOG_ERR, r->connection->log, 0,
                    "Could not get request ID" );
@@ -393,13 +505,15 @@ ngx_akita_send_request_body(ngx_http_request_t *r, ngx_str_t agent_path,
   static ngx_str_t request_arrived_key = ngx_string("request_arrived");
   json_write_string_literal( j, &request_start_key );
   json_write_char( j, ':' );
-  json_write_time_literal( j, &ctx->request_start );
-  
+  json_write_time_literal( j, &ctx->request_start );  
   json_write_char( j, ',' );
+  
   json_write_string_literal( j, &request_arrived_key );
   json_write_char( j, ':' );
   json_write_time_literal( j, &ctx->request_arrived );
-
+  json_write_char( j, ',' );
+                            
+  ngx_akita_write_body( j, r, config->max_body_size );
   json_write_char( j, '}' );
 
   if (j->oom) {

--- a/src/akita_client.h
+++ b/src/akita_client.h
@@ -26,6 +26,7 @@ ngx_akita_client_init(ngx_conf_t *cf);
 ngx_int_t
 ngx_akita_send_request_body(ngx_http_request_t *r, ngx_str_t agent_path,
                             ngx_http_akita_ctx_t *ctx,
+                            ngx_http_akita_loc_conf_t *config,
                             ngx_http_post_subrequest_t *callback);
 
 #endif /* NGX_AKITA_MODULE_AKITA_CLIENT_H_INCLUDED */

--- a/src/ngx_http_akita_module.c
+++ b/src/ngx_http_akita_module.c
@@ -7,13 +7,21 @@
 
 static ngx_int_t
 ngx_http_akita_subrequest_callback(ngx_http_request_t *r, void * data, ngx_int_t rc );
+static void *
+ngx_http_akita_create_loc_conf(ngx_conf_t *cf);
+static char *
+ngx_http_akita_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child);
+static ngx_int_t
+ngx_http_akita_precontent_handler(ngx_http_request_t *r);
+static ngx_int_t
+ngx_http_akita_response_header_filter(ngx_http_request_t *r);
+static ngx_int_t
+ngx_http_akita_response_body_filter(ngx_http_request_t *r, ngx_chain_t *chain);
+static ngx_int_t
+ngx_http_akita_init(ngx_conf_t *cf);
 
-/* Location-specific configuration for the Akita module. */
-typedef struct {
-  /* The network address for the Akita agent REST API.*/  
-  ngx_str_t agent_address;
-  
-} ngx_http_akita_loc_conf_t;
+static const ngx_uint_t default_max_body = 1 * 1024 * 1024;
+static const char default_agent_address[] = "localhost:50800";
 
 /* Create the Akita configuration.
  *
@@ -28,42 +36,49 @@ ngx_http_akita_create_loc_conf(ngx_conf_t *cf) {
     return NULL;
   }
 
-  ngx_str_null( &(conf->agent_address) );
+  conf->max_body_size = NGX_CONF_UNSET_SIZE;
+  conf->enabled = NGX_CONF_UNSET;
   return conf;
 }
 
-/* Merge a parent Akita configuration into the child configuration.
- * Uses "" as the default value that indicates mirroring is not enabled. */
+/* Merge a parent Akita configuration (global or server) into the child configuration (server or location)  */
 static char *
 ngx_http_akita_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child) {
   ngx_http_akita_loc_conf_t *prev = parent;
   ngx_http_akita_loc_conf_t *conf = child;
   
-  ngx_conf_merge_str_value( conf->agent_address, prev->agent_address, "" );
-  
+  ngx_conf_merge_str_value(conf->agent_address, prev->agent_address, default_agent_address);
+  ngx_conf_merge_size_value(conf->max_body_size, prev->max_body_size, default_max_body);
+  ngx_conf_merge_value(conf->enabled, prev->enabled, 0);
   return NGX_CONF_OK;
 }
 
 /* Configuration directives provided by this module. */
 static ngx_command_t ngx_http_akita_commands[] = {
-  /* Enables mirroring of the given location, and specifies the network address of the akita agent. */
+  /* Specifies the network address of the akita agent. */
   { ngx_string("akita_agent"),
     NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
     ngx_conf_set_str_slot,
     NGX_HTTP_LOC_CONF_OFFSET,
     offsetof( ngx_http_akita_loc_conf_t, agent_address ),
     NULL },
+  /* Enable mirroring for a location, server, or globally. */
+  { ngx_string("akita_enable"),
+    NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+    ngx_conf_set_flag_slot,
+    NGX_HTTP_LOC_CONF_OFFSET,
+    offsetof( ngx_http_akita_loc_conf_t, enabled ),
+    NULL },
+  /* Set the maximum body size to capture */
+  { ngx_string("akita_max_body_size"),
+    NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+    ngx_conf_set_size_slot,
+    NGX_HTTP_LOC_CONF_OFFSET,
+    offsetof(ngx_http_akita_loc_conf_t, max_body_size),
+    NULL },
   ngx_null_command
 };
 
-static ngx_int_t
-ngx_http_akita_precontent_handler(ngx_http_request_t *r);
-
-static ngx_int_t
-ngx_http_akita_response_header_filter(ngx_http_request_t *r);
-
-static ngx_int_t
-ngx_http_akita_response_body_filter(ngx_http_request_t *r, ngx_chain_t *chain);
 
 /* The next header-filter handler in the chain. Must be called by our handler
  * once it is done its work.
@@ -145,6 +160,7 @@ static ngx_str_t ngx_http_akita_response_location = ngx_string( "/akita/trace/v1
  */
 static void
 ngx_http_akita_body_callback(ngx_http_request_t *r) {
+  ngx_http_akita_loc_conf_t *akita_config;
   ngx_http_akita_ctx_t *ctx;
 
   if (r->request_body == NULL ) {
@@ -167,8 +183,16 @@ ngx_http_akita_body_callback(ngx_http_request_t *r) {
   callback->handler = ngx_http_akita_subrequest_callback;
   callback->data = NULL;
 
+  /* Retrieve maximum size from configuration */
+  akita_config = ngx_http_get_module_loc_conf(r, ngx_http_akita_module);
+  if (akita_config == NULL) {
+    ngx_log_error( NGX_LOG_INFO, r->connection->log, 0,
+                   "No Akita configuration in callback" );
+    return;
+  }
+  
   /* Send the request metadata and body to Akita */
-  if (ngx_akita_send_request_body(r, ngx_http_akita_request_location, ctx, callback) != NGX_OK) {
+  if (ngx_akita_send_request_body(r, ngx_http_akita_request_location, ctx, akita_config, callback) != NGX_OK) {
     ngx_log_error( NGX_LOG_ERR, r->connection->log, 0,
                    "Failed to send request body to Akita agent" );
     /* Fall through and continue to send the real request! */
@@ -201,7 +225,7 @@ ngx_http_akita_precontent_handler(ngx_http_request_t *r) {
   }
 
   akita_config = ngx_http_get_module_loc_conf(r, ngx_http_akita_module);
-  if ( akita_config == NULL || akita_config->agent_address.len == 0 ) {
+  if ( akita_config == NULL || !akita_config->enabled ) {    
     /* Not enabled for this location. */
     return NGX_DECLINED;
   }

--- a/src/ngx_http_akita_module.h
+++ b/src/ngx_http_akita_module.h
@@ -9,6 +9,19 @@
 #include <ngx_core.h>
 #include <ngx_http.h>
 
+/* Location-specific configuration for the Akita module. */
+typedef struct {
+  /* The network address for the Akita agent REST API.*/  
+  ngx_str_t agent_address;
+
+  /* The max size of a body to send to the Akita agent */
+  size_t max_body_size;
+
+  /* Whether the agent is enabled in this location */
+  ngx_flag_t enabled;
+  
+} ngx_http_akita_loc_conf_t;
+
 /* Context for a particular HTTP request */
 typedef struct {
   /* Have we already handled this request? */


### PR DESCRIPTION
Builds on the previous two by adding HTTP headers.

```
POST /trace/v1/request HTTP/1.1
Host: localhost:5555
Content-Length: 465
Content-Type: application/json

{"request_id":"4ccfcd346724978c19b02e213d06b87f","method":"POST","path":"/users","host":"127.0.0.1:8888",
"headers":[{"header":"Host","value":"127.0.0.1:8888"},{"header":"User-Agent","value":"curl/7.68.0"},
{"header":"Accept","value":"*/*"},{"header":"MyHeader","value":"True"},{"header":"Content-Type","value":"application/json"},
{"header":"Content-Length","value":"18"}],
"request_start":"2023-01-11T05:04:19.603260Z","request_arrived":"2023-01-11T05:04:19.603260Z"}
```