### PR TITLE
Send HTTP response metadata to Akita.

### DIFF
--- a/src/akita_client.c
+++ b/src/akita_client.c
@@ -21,8 +21,9 @@ static unsigned char * json_ensure_space( json_data_t *buf, ngx_uint_t size );
 static void json_write_char( json_data_t *buf, unsigned char c );
 static void json_write_string_literal( json_data_t *buf, ngx_str_t *str );
 static void json_write_time_literal( json_data_t *buf, struct timeval *tm  );
-static void json_write_uint_literal( json_data_t *buf, ngx_uint_t n );
+static void json_write_uint_property( json_data_t *buf, ngx_str_t *key, ngx_uint_t n );
 static void json_snprintf(json_data_t *j, size_t max_len, const char *fmt, ...);
+static ngx_int_t json_escape_buf(json_data_t *j, ngx_http_request_t *r, size_t max_size, size_t *total_size, ngx_buf_t *buf);
 
 /* A key and string value to write into a JSON object */
 typedef struct json_kv_string_s {
@@ -161,10 +162,12 @@ static void json_snprintf(json_data_t *j, size_t max_len, const char *fmt, ...) 
   j->tail->buf->last = end;  
 }
 
-/* Write an unsigned integer to the JSON buffer.
+/* Write a key and an unsigned integer to the JSON buffer.
    Sets 'j->oom' if an error occurs. */
-static void json_write_uint_literal(json_data_t *j, ngx_uint_t n) {
+static void json_write_uint_property(json_data_t *j, ngx_str_t *key, ngx_uint_t n) {  
   const int max_decimal_len = 20; /* handles 64-bit unsigned */
+  json_write_string_literal(j, key);
+  json_write_char(j, ':');
   json_snprintf(j, max_decimal_len, "%ud", n);
 }
 
@@ -294,18 +297,91 @@ ngx_akita_write_headers_list(json_data_t *j, ngx_list_t *headers_list ) {
   json_write_char(j, ']' );  
 }
 
+/*
+ * Write the buffer to a JSON string literal.
+ * Assumes the quotes have already been added.
+  * Update total_size with the actual size.
+  * The portion of the buffer that is written to the JSON literal is limited to
+  * max_size - *total_size, as counted before characters are escaped.
+  *
+  * Returns an Nginx error code.
+ */
+static ngx_int_t
+json_escape_buf(json_data_t *j, ngx_http_request_t *r, size_t max_size, size_t *total_size, ngx_buf_t *buf) {
+  unsigned char *unescaped, *dst;
+  size_t unescaped_len = 0;
+  unsigned char *file_buf = NULL;
+  ssize_t num_read;
+  uintptr_t size_delta;
+
+  /* If at max size, record length */
+  if (*total_size >= max_size) {
+    *total_size += ngx_buf_size(buf);
+    return NGX_OK;
+  }
+
+  unescaped_len = ngx_buf_size(buf);
+  /* Truncate if over max size */
+  if (*total_size + unescaped_len > max_size) {
+    unescaped_len = max_size - *total_size;
+  }
+  /* Record the real size */
+  *total_size += ngx_buf_size(buf);
+ 
+  if (ngx_buf_in_memory(buf)) {
+    unescaped = buf->pos;
+  } else if (buf->in_file) {
+    /* Allocate a buffer; don't bother clearing it. */
+    file_buf = ngx_palloc(r->connection->pool, unescaped_len);
+    if (file_buf == NULL) {
+      return NGX_ERROR;
+    }
+    
+    /* TODO: this is blocking, but hooking into the event system
+     * to read it in a non-blocking fashion seems difficult. */
+    num_read = ngx_read_file( buf->file, file_buf, unescaped_len, buf->file_pos );
+    if (num_read < 0) {
+      ngx_log_error(NGX_LOG_ERR, r->connection->log, ngx_errno,
+                    "Couldn't read buffered file");
+      return NGX_ERROR;
+    }
+    unescaped = file_buf;
+  } else if (buf->last_buf) {
+    /* Empty buf allowed at the end of a chain */
+    return NGX_OK;
+  } else {
+    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "Unexpected buffer state");
+    return NGX_ERROR;
+  }
+
+  size_delta = ngx_escape_json(NULL, unescaped, unescaped_len);
+  dst = json_ensure_space(j, unescaped_len + size_delta);
+  if (dst == NULL) {
+    return NGX_ERROR;
+  }
+  dst = (unsigned char *)ngx_escape_json(dst, unescaped, unescaped_len);
+  j->content_length += (unescaped_len + size_delta);
+  j->tail->buf->last = dst;
+
+  if (file_buf != NULL) {
+    /*
+     * If the buffer was large enough, return it to the system allocator.
+     * If too small, this is a no-op.
+     */
+    ngx_pfree(r->connection->pool, file_buf);
+    file_buf = NULL;
+  }
+  
+  return NGX_OK;
+}
+
 /* Write the contents of the body, up to the given size, as a 
    JSON literal string. If the content is truncated,
    indicate this by a "truncated" field giving the truncated size. */
 static void
 ngx_akita_write_body(json_data_t *j, ngx_http_request_t *r, size_t max_size ) {
-  uintptr_t sz;
-  ngx_chain_t  *in;
-  static unsigned char *unescaped, *dst;
-  static unsigned char *file_buf = NULL;
-  size_t unescaped_len = 0;
-  size_t mirrored = 0;  /* must be <= max_size */
-  size_t truncated = 0; 
+  ngx_chain_t *in;
+  size_t total_size = 0; 
   static ngx_str_t body_key = ngx_string( "body" );
   static ngx_str_t truncated_key = ngx_string( "truncated" );
   
@@ -319,71 +395,18 @@ ngx_akita_write_body(json_data_t *j, ngx_http_request_t *r, size_t max_size ) {
   }
   
   for (in = r->request_body->bufs; in; in = in->next) {
-    /* Add up size after hitting limit*/
-    if (truncated > 0) {
-      truncated += ngx_buf_size(in->buf);
-      continue;
-    }
-    if (ngx_buf_in_memory(in->buf)) {
-      unescaped = in->buf->pos;
-      unescaped_len = in->buf->last - in->buf->pos;
-
-      /* Trim to maximum size, flag truncation. */
-      if (mirrored + unescaped_len > max_size) {
-        truncated = mirrored + unescaped_len;
-        unescaped_len = max_size - mirrored;
-      }
-    } else if (in->buf->in_file) {
-      /* Allocate a buffer and read only as much as we need from the file */
-      unescaped_len = in->buf->file_last - in->buf->file_pos;
-
-      if (mirrored + unescaped_len > max_size) {
-        truncated = mirrored + unescaped_len;
-        unescaped_len = max_size - mirrored;
-      }
-
-      /* Allocate a buffer; don't bother clearing it? */
-      file_buf = ngx_palloc(r->connection->pool, unescaped_len);
-      if (file_buf == NULL) {
-        j->oom = 1;
-        return;
-      }
-
-      /* TODO: this is blocking, but I don't know how to go through the
-       * event system to make it nonblocking. */
-      ngx_read_file( in->buf->file, file_buf, unescaped_len, in->buf->file_pos );
-      unescaped = file_buf;
-    } else if (in->buf->last_buf) {
-      break;
-    } else {
-      ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "Unexpected buffer state");
-      break;
-    }
-
-    sz = ngx_escape_json( NULL, unescaped, unescaped_len );
-    dst = json_ensure_space( j, unescaped_len + sz );
-    if (dst == NULL) {
+    if (json_escape_buf(j, r, max_size, &total_size, in->buf) != NGX_OK) {
+      /* TODO: a better way of signalling the error */
+      j->oom = 1;
       return;
-    }
-    dst = (unsigned char *)ngx_escape_json( dst, unescaped, unescaped_len );
-    mirrored += unescaped_len;
-    j->content_length += (unescaped_len + sz);
-    j->tail->buf->last = dst;
-
-    if (file_buf != NULL) {
-      /* If the buffer was large enough, return it to the system allocator */
-      ngx_pfree(r->connection->pool, file_buf);
-      file_buf = NULL;
-    }
+    }    
   }
 
   json_write_char( j, '"' );
 
-  if (truncated > 0) {
+  if (total_size > max_size) {
     json_write_char(j, ',');
-    json_write_string_literal(j, &truncated_key);
-    json_write_char(j, ':');
-    json_write_uint_literal(j, truncated);
+    json_write_uint_property(j, &truncated_key, total_size);
   }
 }
 
@@ -593,10 +616,8 @@ typedef struct ngx_akita_internal_header_s {
 } ngx_akita_internal_header_t;
 
 ngx_int_t
-ngx_akita_send_response_headers(ngx_http_request_t *r, ngx_str_t agent_path,
-                                ngx_http_akita_ctx_t *ctx,
-                                ngx_http_akita_loc_conf_t *config,
-                                ngx_http_post_subrequest_t *callback) {
+ngx_akita_start_response_body(ngx_http_request_t *r, 
+                              ngx_http_akita_ctx_t *ctx) {
   u_char *buf;
   json_data_t *j;
   ngx_str_t request_id;
@@ -629,10 +650,8 @@ ngx_akita_send_response_headers(ngx_http_request_t *r, ngx_str_t agent_path,
   json_write_char( j, ',' );
 
   static ngx_str_t response_code_key = ngx_string( "response_code" );
-  json_write_string_literal(j, &response_code_key);
-  json_write_char(j, ':');
-  json_write_uint_literal(j, r->headers_out.status);
-  json_write_char(j, ',');
+  json_write_uint_property(j, &response_code_key, r->headers_out.status);
+  json_write_char( j, ',' );
 
   /* Nginx-written headers are not present, nor are the ones from 
    * the upstream response that will be overwritten?  See
@@ -708,9 +727,13 @@ ngx_akita_send_response_headers(ngx_http_request_t *r, ngx_str_t agent_path,
   static ngx_str_t response_start_key = ngx_string("response_start");
   json_write_string_literal( j, &response_start_key );
   json_write_char( j, ':' );
-  json_write_time_literal( j, &ctx->response_start );  
-
-  json_write_char( j, '}' );
+  json_write_time_literal( j, &ctx->response_start );
+  json_write_char( j, ',' );
+  
+  static ngx_str_t body_key = ngx_string( "body" );
+  json_write_string_literal( j, &body_key );
+  json_write_char( j, ':' );
+  json_write_char( j, '"' );
 
   if (j->oom) {
     ngx_log_error( NGX_LOG_ERR, r->connection->log, 0,
@@ -718,6 +741,70 @@ ngx_akita_send_response_headers(ngx_http_request_t *r, ngx_str_t agent_path,
     return NGX_ERROR;
   }
 
+  /* 
+   * Set up context for rest of body.
+   * The body filter is called even when content length is zero or
+   * the response is a 204.
+   */
+  ctx->response_json = j;
+  ctx->response_body_size = 0;
+
+  return NGX_OK;
+}
+
+ngx_int_t
+ngx_akita_append_response_body(ngx_http_request_t *r,
+                               ngx_http_akita_ctx_t *ctx,
+                               ngx_http_akita_loc_conf_t *config,
+                               ngx_buf_t *buf) {
+  ngx_int_t err;
+  err = json_escape_buf(ctx->response_json, r,
+                        config->max_body_size,
+                        &ctx->response_body_size,
+                        buf);
+  if (err != NGX_OK) {
+    return err;
+  }
+  if (ctx->response_json->oom) {
+    ngx_log_error( NGX_LOG_ERR, r->connection->log, 0,
+                   "JSON body got out-of-memory" );
+    return NGX_ERROR;
+  }
+  return NGX_OK;
+}
+
+ngx_int_t
+ngx_akita_finish_response_body(ngx_http_request_t *r,
+                               ngx_str_t agent_path,
+                               ngx_http_akita_ctx_t *ctx,
+                               ngx_http_akita_loc_conf_t *config,
+                               ngx_http_post_subrequest_t *callback) {
+  json_data_t *j = ctx->response_json;
+
+  /* Finish the literal that contains the response body */
+  json_write_char( j, '"' );
+  json_write_char( j, ',' );
+
+  /* Mark if the body was truncated, and its actual size */
+  if (ctx->response_body_size > config->max_body_size) {
+    static ngx_str_t truncated_key = ngx_string( "truncated" );
+    json_write_uint_property(j, &truncated_key, ctx->response_body_size);
+    json_write_char( j, ',' );
+  }
+  
+  static ngx_str_t response_start_key = ngx_string("response_complete");
+  json_write_string_literal( j, &response_start_key );
+  json_write_char( j, ':' );
+  json_write_time_literal( j, &ctx->response_complete );
+
+  json_write_char( j, '}' );
+  
+  if (j->oom) {
+    ngx_log_error( NGX_LOG_ERR, r->connection->log, 0,
+                   "JSON body got out-of-memory" );
+    return NGX_ERROR;
+  }
+  
   /* Mark end of body */
   j->tail->buf->last_buf = 1;
 

--- a/src/akita_client.h
+++ b/src/akita_client.h
@@ -29,10 +29,38 @@ ngx_akita_send_request_body(ngx_http_request_t *r, ngx_str_t agent_path,
                             ngx_http_akita_loc_conf_t *config,
                             ngx_http_post_subrequest_t *callback);
 
+/*
+ * Records the response's metadata and start building its response body.
+ * Allocates ctx->response_json from the pool in r. On return,
+ * ctx->response_json will have a JSON string for the response body started,
+ * but not yet terminated.
+ */
 ngx_int_t
-ngx_akita_send_response_headers(ngx_http_request_t *r, ngx_str_t agent_path,
-                                ngx_http_akita_ctx_t *ctx,
-                                ngx_http_akita_loc_conf_t *config,
-                                ngx_http_post_subrequest_t *callback);
+ngx_akita_start_response_body(ngx_http_request_t *r,
+                              ngx_http_akita_ctx_t *ctx);
+
+/*
+ * Add a buffer from the response body to the mirrored API call's JSON
+ * response. The buffer is JSON-escaped as it is written, and
+ * ctx->json_response is assumed to be in the middle of an as-yet unterminated
+ * JSON string.
+ */
+ngx_int_t
+ngx_akita_append_response_body(ngx_http_request_t *r,
+                               ngx_http_akita_ctx_t *ctx,
+                               ngx_http_akita_loc_conf_t *config,
+                               ngx_buf_t *);
+
+/*
+ * Finish sending the response body to Akita, using the partially
+ * assembled JSON body in ctx->json_response. Create a new subrequest
+ * of the original request r, and send it to agent_path. 
+ */
+ngx_int_t
+ngx_akita_finish_response_body(ngx_http_request_t *r,
+                               ngx_str_t agent_path,
+                               ngx_http_akita_ctx_t *ctx,
+                               ngx_http_akita_loc_conf_t *config,
+                               ngx_http_post_subrequest_t *callback);
 
 #endif /* NGX_AKITA_MODULE_AKITA_CLIENT_H_INCLUDED */

--- a/src/ngx_http_akita_module.h
+++ b/src/ngx_http_akita_module.h
@@ -19,14 +19,20 @@ typedef struct {
 
   /* Whether the agent is enabled in this location */
   ngx_flag_t enabled;
-  
+
 } ngx_http_akita_loc_conf_t;
+
+/* Forward declaration of JSON buffer */
+struct json_data_s;
 
 /* Context for a particular HTTP request */
 typedef struct {
   /* Have we already handled this request? */
   ngx_int_t      status;
 
+  /* Continue processing this request? */
+  ngx_flag_t      enabled;
+  
   /* Time when request is first observed and when its body is available */
   struct timeval request_start;
   struct timeval request_arrived;
@@ -35,7 +41,11 @@ typedef struct {
   struct timeval response_start;
   struct timeval response_complete;
   
-  /* TODO: Buffered response data. */
+  /* JSON buffer holding the Akita API call for a response body. 
+   * The response filter can write escaped data to it until the end of body 
+   * or the body size limit. */
+  struct json_data_s *response_json;
+  size_t response_body_size;
 } ngx_http_akita_ctx_t;
 
 #endif /* _NGX_HTTP_AKITA_MODULE_H_INCLUDED */


### PR DESCRIPTION
(I'm not 100% sure that we need to make the call here, or if we can wait until the body filter and send everything-- I need to experiment if the body filter is called when there's no body.)

Refactored code to call a REST API into a shared function.
Replaced PoC with the real thing in header filter.

Replaces #7 with a cleaner history