### PR TITLE
Back off for 30 seconds (doubling up to 240 seconds) on agent failure.

### DIFF
--- a/src/ngx_http_akita_module.c
+++ b/src/ngx_http_akita_module.c
@@ -541,6 +541,7 @@ ngx_http_akita_response_body_filter(ngx_http_request_t *r, ngx_chain_t *chain) {
 static time_t ngx_http_akita_agent_retry_time;
 static ngx_uint_t ngx_http_akita_agent_backoff;
 
+/* Minimum and maximum backoff period, in seconds */
 static const int ngx_http_akita_agent_initial_backoff = 30;
 static const int ngx_http_akita_agent_max_backoff = 240;
 


### PR DESCRIPTION
This state is per worker process, so different processes may have different timeouts.

If the agent is completely down then we will induce 2 seconds of delay to all requests, every 240 seconds.  Maybe we should change the logic to allow just one request through, and then re-enable everybody if it succeeds?

(A better strategy would be to add a background even to poll until the server responds, but I don't think that can work with the current architecture.)

